### PR TITLE
Update license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     },
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
+        "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
     package_dir={"": "src"},


### PR DESCRIPTION
## Summary
- update the license classifier in setup.py from MIT to Apache
- run tests

## Testing
- `pytest tests/ -q` *(fails: AttributeError: module 'matplotlib.cm' has no attribute 'register_cmap')*

------
https://chatgpt.com/codex/tasks/task_b_6887064bedc88327baa2bd29c9a757db