### PR TITLE
Fix typo in plotting comments

### DIFF
--- a/src/plotting.py
+++ b/src/plotting.py
@@ -186,7 +186,7 @@ class Plotting:
         # Before plotting, store params_df to a csv file
         self.store_baseline_params(params_df)
 
-        # plot the virtual baseline paramters
+        # plot the virtual baseline parameters
         for param in self.parent.parameter_names:
             points = np.array(
                 [params_df.index.values, params_df[param].values]
@@ -316,7 +316,7 @@ class Plotting:
         # Before plotting, store params_df to a csv file
         self.store_baseline_params(params_df)
 
-        # plot the virtual baseline paramters
+        # plot the virtual baseline parameters
         for param in self.parent.parameter_names:
             points = np.array(
                 [params_df.index.values, params_df[param].values]


### PR DESCRIPTION
## Summary
- fix spelling error 'paramters' -> 'parameters' in plotting module

## Testing
- `pytest tests -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_6887066d4be48327a6582b6b26d138e1