### PR TITLE
Fix cumulative typo in df_utils

### DIFF
--- a/src/df_utils.py
+++ b/src/df_utils.py
@@ -123,12 +123,12 @@ def eval_cumm(df, group_on, resource_col, response_col, opt_sense):
     Returns
     -------
     df : pd.DataFrame
-        Datafram with the cummulative evaluation
+        Dataframe with the cumulative evaluation
     """
 
     def cummSingle(single_df):
         single_df = monotone_df(single_df.copy(), resource_col, response_col, 1)
-        single_df.loc[:, "cummulative" + resource_col] = (
+        single_df.loc[:, "cumulative" + resource_col] = (
             single_df[resource_col].expanding(min_periods=1).sum()
         )
         return single_df

--- a/tests/test_df_utils.py
+++ b/tests/test_df_utils.py
@@ -184,12 +184,12 @@ class TestEvalCumm:
         result = eval_cumm(df, ['group'], 'resource', 'response', opt_sense=1)
         
         assert isinstance(result, pd.DataFrame)
-        assert 'cummulativeresource' in result.columns
+        assert 'cumulativeresource' in result.columns
         
         # Check cumulative resource calculation
         group_a = result[result['group'] == 'A'].sort_values('resource')
         expected_cumm = [1, 3, 6]  # Cumulative sum of [1, 2, 3]
-        np.testing.assert_array_equal(group_a['cummulativeresource'].values, expected_cumm)
+        np.testing.assert_array_equal(group_a['cumulativeresource'].values, expected_cumm)
     
     def test_eval_cumm_multiple_groups(self):
         """Test cumulative evaluation with multiple groups."""
@@ -204,7 +204,7 @@ class TestEvalCumm:
         
         assert isinstance(result, pd.DataFrame)
         assert len(result) == 4  # Same number of rows
-        assert 'cummulativeresource' in result.columns
+        assert 'cumulativeresource' in result.columns
 
 
 class TestReadExpRaw:


### PR DESCRIPTION
## Summary
- fix 'cummulative' typo in `src/df_utils.py`
- update tests to expect the corrected 'cumulativeresource' column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_688707119e7c8327957b5aff15ec49a4