### PR TITLE
Fix docstring typo in virtual_best

### DIFF
--- a/src/training.py
+++ b/src/training.py
@@ -85,7 +85,7 @@ def virtual_best(
         Maximizing (1) or minimizing(-1)
     groupby : list[str]
         columns that define and instance
-    resouce_col : str
+    resource_col : str
     additional_cols : list[str]
         Additional columns that should be kept in the dataframe
     smooth: bool


### PR DESCRIPTION
## Summary
- fix spelling of `resource_col` in `training.virtual_best` docstring

## Testing
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_b_6887071690a08327afc49279cdd1f6f1