### PR TITLE
Fix repo name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ The current package implements the following functionality:
 
 1. **Clone the Repository**:
     ```bash
-    git clone https://github.com/usra-riacs/stochastic-benchmarking.git
-    cd stochastic-benchmarking
+    git clone https://github.com/usra-riacs/stochastic-benchmark.git
+    cd stochastic-benchmark
     ```
 
 2. **Set up a Virtual Environment (Recommended)**:
@@ -64,7 +64,7 @@ The current package implements the following functionality:
 ### Method 2: Downloading as a Zip Archive
 
 1. **Download the Repository**:
-    - Navigate to the [stochastic-benchmarking GitHub page](https://github.com/usra-riacs/stochastic-benchmarking).
+    - Navigate to the [stochastic-benchmark GitHub page](https://github.com/usra-riacs/stochastic-benchmark).
     - Click on the `Code` button.
     - Choose `Download ZIP`.
     - Once downloaded, extract the ZIP archive and navigate to the extracted folder in your terminal or command prompt.
@@ -86,7 +86,7 @@ The current package implements the following functionality:
 
 ## Examples
 
-For a full demonstration of the stochastic-benchmarking analysis in action, refer to the example notebooks located in the `examples` folder of this repository.
+For a full demonstration of the stochastic-benchmark analysis in action, refer to the example notebooks located in the `examples` folder of this repository.
 
 ## Contributors
 - [@robinabrown](https://github.com/robinabrown) Robin Brown


### PR DESCRIPTION
## Summary
- update cloning instructions
- update GitHub links
- fix example section wording

## Testing
- `python run_tests.py smoke` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_6887067107688327ba16345ddc10d766