### PR TITLE
Fix level columns removal in monotone_df

### DIFF
--- a/src/df_utils.py
+++ b/src/df_utils.py
@@ -101,7 +101,7 @@ def monotone_df(
                 df.loc[idx, rolling_cols] = matched_row[rolling_cols].copy()
         else:
             prev_row = row.copy()
-    df.drop(columns=[c for c in df.columns if "level" in c])
+    df.drop(columns=[c for c in df.columns if "level" in c], inplace=True)
     return df
 
 

--- a/tests/test_df_utils.py
+++ b/tests/test_df_utils.py
@@ -163,11 +163,30 @@ class TestMonotoneDf:
             'response': [5, 10, 15, 20, 25],  # Already monotonic
             'other_col': ['a', 'b', 'c', 'd', 'e']
         })
-        
+
         result = monotone_df(df.copy(), 'resource', 'response', opt_sense=1)
-        
+
         # Should be unchanged (already monotonic)
         np.testing.assert_array_equal(result['response'].values, [5, 10, 15, 20, 25])
+
+    def test_monotone_df_drops_level_columns(self):
+        """Monotone_df should remove groupby generated level columns."""
+        base_df = pd.DataFrame({
+            'resource': [1, 2, 1, 2],
+            'response': [3, 4, 5, 6],
+            'group': ['A', 'A', 'B', 'B']
+        })
+
+        grouped = base_df.groupby('group', as_index=False).apply(lambda x: x)
+        df_with_levels = grouped.reset_index()
+
+        assert 'level_0' in df_with_levels.columns  # ensure levels are present
+
+        result = monotone_df(df_with_levels.copy(), 'resource', 'response', opt_sense=1)
+
+        # Ensure level columns are removed
+        assert 'level_0' not in result.columns
+        assert 'level_1' not in result.columns
 
 
 class TestEvalCumm:


### PR DESCRIPTION
## Summary
- ensure `monotone_df` drops `level_*` columns in place
- add regression test verifying temporary groupby columns are removed

## Testing
- `PYTHONPATH=src pytest tests/test_df_utils.py::TestMonotoneDf::test_monotone_df_drops_level_columns -q`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688707747fe883278e99b268df53a3c1