### PR TITLE
Add tests to improve coverage

### DIFF
--- a/tests/test_cross_validation.py
+++ b/tests/test_cross_validation.py
@@ -1,0 +1,88 @@
+import pytest
+import pandas as pd
+import numpy as np
+
+import sys
+sys.path.insert(0, 'src')
+
+if not hasattr(pd.DataFrame, 'iteritems'):
+    pd.DataFrame.iteritems = pd.DataFrame.items
+
+from cross_validation import (
+    baseline_evaluate,
+    all_ci,
+    propagate_ci,
+    random_exp_evaluate,
+    seq_search_evaluate,
+)
+
+
+class TestBaselineEvaluate:
+    def test_basic(self):
+        df = pd.DataFrame({
+            'resource': [1, 1, 2, 2],
+            'param1': [0.1, 0.2, 0.3, 0.4],
+            'response': [10, 20, 30, 40]
+        })
+        params_df, eval_df = baseline_evaluate(df, ['param1'], 'response')
+        assert list(params_df.columns) == ['resource', 'param1']
+        assert list(eval_df.columns) == ['resource', 'response']
+        assert len(params_df) == 2
+        assert len(eval_df) == 2
+
+
+class TestAllCI:
+    def test_all_ci_basic(self):
+        df = pd.DataFrame({'resource': [1,2,3], 'p': [1.0, 2.0, 3.0]})
+        res = all_ci(df, 'p', confidence_level=68)
+        assert 'mean' in res.columns
+        assert 'CI_l' in res.columns
+        assert 'CI_u' in res.columns
+        assert res['mean'].iloc[0] == pytest.approx(2.0)
+
+
+class TestPropagateCI:
+    def test_propagate_ci_mean(self):
+        df = pd.DataFrame({
+            'response': [1.0, 2.0, 3.0],
+            'response_lower': [0.5, 1.5, 2.5],
+            'response_upper': [1.5, 2.5, 3.5]
+        })
+        res = propagate_ci(df, 'mean')
+        assert {'mean','CI_l','CI_u'} <= set(res.columns)
+
+    def test_invalid_measure(self):
+        df = pd.DataFrame({'response':[1],'response_lower':[0],'response_upper':[2]})
+        with pytest.raises(ValueError):
+            propagate_ci(df, 'other')
+
+
+class TestEvaluateFuncs:
+    def test_random_exp_evaluate(self):
+        df = pd.DataFrame({
+            'TotalBudget':[10,10,20,20],
+            'resource':[1,2,1,2],
+            'param1':[0.1,0.2,0.3,0.4],
+            'Resp':[10,20,30,40],
+            'ConfInt=lower_Resp':[9,18,28,38],
+            'ConfInt=upper_Resp':[11,22,32,42]
+        })
+        params_df, eval_df = random_exp_evaluate(df, ['param1'], 'Resp')
+        assert 'resource' in params_df.columns
+        assert 'response' in eval_df.columns
+        assert len(params_df) == 2
+
+    def test_seq_search_evaluate(self):
+        df = pd.DataFrame({
+            'TotalBudget':[10,20],
+            'param1':[0.1,0.2],
+            'resource':[5,5],
+            'Resp':[11,12],
+            'ConfInt=upper_Resp':[12,13],
+            'ConfInt=lower_Resp':[10,11]
+        })
+        params_df, eval_df = seq_search_evaluate(df, ['param1'], 'Resp')
+        assert 'resource' in params_df.columns
+        assert len(eval_df) == 2
+
+

--- a/tests/test_exploration.py
+++ b/tests/test_exploration.py
@@ -1,0 +1,61 @@
+import pytest
+import pandas as pd
+import numpy as np
+
+import sys
+sys.path.insert(0, 'src')
+
+if not hasattr(pd.DataFrame, 'iteritems'):
+    pd.DataFrame.iteritems = pd.DataFrame.items
+
+from random_exploration import RandomSearchParameters, prepare_search as rs_prepare, summarize_experiments as rs_summary
+from sequential_exploration import SequentialSearchParameters, prepare_search as ss_prepare, summarize_experiments as ss_summary
+import stats
+
+
+class TestRandomExploration:
+    def test_prepare_search(self):
+        df = pd.DataFrame({'resource':[10,20,30]})
+        params = RandomSearchParameters(taus=[5,15,25])
+        rs_prepare(df, params)
+        assert list(params.taus) == [10,20]
+
+    def test_summarize_experiments(self):
+        df = pd.DataFrame({
+            'TotalBudget':[100,100],
+            'ExplorationBudget':[50,50],
+            'tau':[10,10],
+            'PerfRatio':[0.8,0.9]
+        })
+        params = RandomSearchParameters()
+        params.key = 'PerfRatio'
+        params.stat_measure = stats.Mean()
+        params.optimization_dir = 1
+        best, exp = rs_summary(df, params)
+        assert len(best) == 1
+        assert len(exp) >= 1
+
+
+class TestSequentialExploration:
+    def test_prepare_search(self):
+        df = pd.DataFrame({'resource':[10,20,30]})
+        params = SequentialSearchParameters(taus=[8,18,25])
+        ss_prepare(df, params)
+        assert list(params.taus) == [10,20]
+
+    def test_summarize_experiments(self):
+        df = pd.DataFrame({
+            'TotalBudget':[100,100],
+            'ExplorationBudget':[50,50],
+            'tau':[10,10],
+            'PerfRatio':[0.8,0.7]
+        })
+        params = SequentialSearchParameters()
+        params.key = 'PerfRatio'
+        params.stat_measure = stats.Mean()
+        params.optimization_dir = -1
+        best, exp = ss_summary(df, params)
+        assert len(best) == 1
+        assert len(exp) >= 1
+
+

--- a/tests/test_utils_ws.py
+++ b/tests/test_utils_ws.py
@@ -1,0 +1,44 @@
+import pytest
+import pandas as pd
+import numpy as np
+
+import sys
+sys.path.insert(0, 'src')
+
+# Compatibility for pandas 2.x
+if not hasattr(pd.DataFrame, 'iteritems'):
+    pd.DataFrame.iteritems = pd.DataFrame.items
+
+from utils_ws import gen_log_space, interp, take_closest
+
+
+class TestGenLogSpace:
+    def test_basic_generation(self):
+        result = gen_log_space(1, 10, 3)
+        assert isinstance(result, np.ndarray)
+        assert list(result) == [1, 3, 9]
+        assert len(result) == 3
+
+
+class TestTakeClosest:
+    def test_take_closest_middle(self):
+        lst = [1, 3, 5, 7]
+        value = 4
+        assert take_closest(lst, value) == 3
+
+    def test_take_closest_edges(self):
+        lst = [10, 20, 30]
+        assert take_closest(lst, 5) == 10
+        assert take_closest(lst, 35) == 30
+
+
+class TestInterp:
+    def test_interp_numeric(self):
+        df = pd.DataFrame({'a': [1, 3], 'b': [10, 20]}, index=[0, 1])
+        new_idx = [0, 0.5, 1]
+        out = interp(df, new_idx)
+        assert list(out.index) == new_idx
+        np.testing.assert_array_almost_equal(out['a'].values, [1, 2, 3])
+        np.testing.assert_array_almost_equal(out['b'].values, [10, 15, 20])
+
+


### PR DESCRIPTION
## Summary
- add unit tests for utils_ws helper functions
- test cross_validation helpers for CI computation and evaluation routines
- cover basic behavior of random and sequential exploration utilities
- remove `pytest.main` blocks from new tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6887068685408327938687f6b83c14fc