### PR TITLE
Add testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Details of the implementation and an illustrative example for Wishart instances 
 - [Background](#background)
 - [Installation](#installation)
 - [Examples](#examples)
+- [Testing](#testing)
 - [Contributors](#contributors)
 - [Acknowledgements](#acknowledgements)
 - [License](#license)
@@ -87,6 +88,31 @@ The current package implements the following functionality:
 ## Examples
 
 For a full demonstration of the stochastic-benchmarking analysis in action, refer to the example notebooks located in the `examples` folder of this repository.
+
+## Testing
+
+Tests can be executed using the helper script `run_tests.py`. Specify the type of
+tests to run along with any optional flags:
+
+```bash
+python run_tests.py [unit|integration|smoke|all|coverage] [--verbose] [--fast]
+```
+
+Example commands:
+
+- Run the unit test suite:
+
+  ```bash
+  python run_tests.py unit
+  ```
+
+- Generate a coverage report:
+
+  ```bash
+  python run_tests.py coverage
+  ```
+
+For additional details see [TESTING.md](TESTING.md).
 
 ## Contributors
 - [@robinabrown](https://github.com/robinabrown) Robin Brown

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ dill==0.3.5.1
 fonttools==4.25.0
 future==0.18.3
 hyperopt==0.2.7
-mkl-service==2.4.0
+mkl-service==2.5.0
 multiprocess==0.70.13
 munkres==1.1.4
 networkx==2.8.6

--- a/run_tests.py
+++ b/run_tests.py
@@ -9,6 +9,7 @@ import argparse
 import subprocess
 import sys
 import os
+import glob
 
 def run_command(cmd, description):
     """Run a command and handle errors."""
@@ -60,12 +61,18 @@ def main():
     success = True
     
     if args.test_type == "unit" or args.test_type == "all":
-        cmd = ["python", "-m", "pytest", "tests/test_*.py"]
-        if args.verbose:
-            cmd.append("-v")
-        if args.fast:
-            cmd.extend(["-m", "not slow"])
-        success &= run_command(cmd, "Unit tests")
+        # Expand glob pattern manually so pytest receives explicit file paths
+        unit_files = sorted(glob.glob(os.path.join("tests", "test_*.py")))
+        if not unit_files:
+            print("No unit test files found")
+            success &= False
+        else:
+            cmd = ["python", "-m", "pytest", *unit_files]
+            if args.verbose:
+                cmd.append("-v")
+            if args.fast:
+                cmd.extend(["-m", "not slow"])
+            success &= run_command(cmd, "Unit tests")
     
     if args.test_type == "integration" or args.test_type == "all":
         cmd = ["python", "-m", "pytest", "tests/integration/"]


### PR DESCRIPTION
## Summary
- add testing section to README with examples
- update mkl-service version in requirements
- fix run_tests.py wildcard handling for unit tests

## Testing
- `pip install numpy pandas networkx cloudpickle dill tqdm multiprocess hyperopt mkl-service==2.5.0`
- `pip install matplotlib`
- `pip install pytest-cov`
- `python run_tests.py unit -v`
- `python run_tests.py integration -v`
- `python run_tests.py smoke -v`
- `python run_tests.py coverage -v`
- `python run_tests.py all -v`


------
https://chatgpt.com/codex/tasks/task_b_68870757092c8327b641c866c664a185