### PR TITLE
Add exploration unit tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 cloudpickle==2.2.0
-dill==0.3.5.1
+dill==0.3.8
 fonttools==4.25.0
 future==0.18.3
 hyperopt==0.2.7
-mkl-service==2.4.0
+mkl-service==2.5.2
 multiprocess==0.70.13
 munkres==1.1.4
 networkx==2.8.6

--- a/tests/integration/test_module_integration.py
+++ b/tests/integration/test_module_integration.py
@@ -11,7 +11,9 @@ if not hasattr(pd.DataFrame, 'iteritems'):
     pd.DataFrame.iteritems = pd.DataFrame.items
 
 # Add src directory to path
-sys.path.insert(0, '/home/runner/work/stochastic-benchmark/stochastic-benchmark/src')
+TESTS_DIR = os.path.dirname(__file__)
+SRC_PATH = os.path.abspath(os.path.join(TESTS_DIR, os.pardir, os.pardir, 'src'))
+sys.path.insert(0, SRC_PATH)
 
 # Import modules to test integration
 import names

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -9,7 +9,9 @@ import copy
 
 # Import the module to test
 import sys
-sys.path.insert(0, '/home/runner/work/stochastic-benchmark/stochastic-benchmark/src')
+TESTS_DIR = os.path.dirname(__file__)
+SRC_PATH = os.path.abspath(os.path.join(TESTS_DIR, os.pardir, 'src'))
+sys.path.insert(0, SRC_PATH)
 
 from bootstrap import (
     BootstrapParameters,

--- a/tests/test_df_utils.py
+++ b/tests/test_df_utils.py
@@ -8,7 +8,9 @@ from unittest.mock import patch, MagicMock
 
 # Import the module to test
 import sys
-sys.path.insert(0, '/home/runner/work/stochastic-benchmark/stochastic-benchmark/src')
+TESTS_DIR = os.path.dirname(__file__)
+SRC_PATH = os.path.abspath(os.path.join(TESTS_DIR, os.pardir, 'src'))
+sys.path.insert(0, SRC_PATH)
 
 from df_utils import (
     applyParallel,

--- a/tests/test_exploration.py
+++ b/tests/test_exploration.py
@@ -1,0 +1,111 @@
+import pytest
+import pandas as pd
+import numpy as np
+import sys
+import os
+
+# Monkey patch pandas DataFrame iteritems for pandas>=2
+if not hasattr(pd.DataFrame, 'iteritems'):
+    pd.DataFrame.iteritems = pd.DataFrame.items
+
+# Add src directory to path for imports
+TESTS_DIR = os.path.dirname(__file__)
+SRC_PATH = os.path.abspath(os.path.join(TESTS_DIR, os.pardir, 'src'))
+sys.path.insert(0, SRC_PATH)
+
+import names
+import random_exploration
+import sequential_exploration
+
+
+def create_test_df():
+    """Create a simple dataframe for exploration tests."""
+    key = names.param2filename({"Key": "PerfRatio"}, "")
+    CIlower = names.param2filename({"Key": "PerfRatio", "ConfInt": "lower"}, "")
+    CIupper = names.param2filename({"Key": "PerfRatio", "ConfInt": "upper"}, "")
+    df = pd.DataFrame({
+        'resource': [5, 10],
+        'sweep': [0, 0],
+        'replica': [0, 0],
+        'order': [1, 2],
+        key: [0.5, 0.8],
+        CIlower: [0.4, 0.7],
+        CIupper: [0.6, 0.9]
+    })
+    return df, key
+
+
+class TestRandomSingle:
+    """Tests for random_exploration.single_experiment."""
+
+    def test_single_experiment_basic(self):
+        df, key = create_test_df()
+        params = random_exploration.RandomSearchParameters(
+            budgets=[10],
+            exploration_fracs=[0.5],
+            Nexperiments=1,
+            taus=[5],
+            parameter_names=['sweep', 'replica'],
+            key=key
+        )
+        result = random_exploration.single_experiment(df, params, 10, 0.5, 5)
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 2
+        assert 1 in result['exploit'].values
+        assert result['CummResource'].iloc[-1] <= 10
+
+    def test_single_experiment_insufficient_budget(self):
+        df, key = create_test_df()
+        params = random_exploration.RandomSearchParameters(
+            budgets=[10],
+            exploration_fracs=[0.5],
+            Nexperiments=1,
+            taus=[5],
+            parameter_names=['sweep', 'replica'],
+            key=key
+        )
+        # explore_budget < tau should return None
+        result = random_exploration.single_experiment(df, params, 4, 0.5, 5)
+        assert result is None
+
+
+class TestSequentialSingle:
+    """Tests for sequential_exploration.SequentialExplorationSingle."""
+
+    def test_sequential_single_basic(self):
+        df, key = create_test_df()
+        params = sequential_exploration.SequentialSearchParameters(
+            budgets=[10],
+            exploration_fracs=[0.5],
+            taus=[5],
+            order_cols=['order'],
+            parameter_names=['sweep', 'replica'],
+            key=key
+        )
+        result = sequential_exploration.SequentialExplorationSingle(df, params, 0, 10, 0.5, 5)
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 2
+        assert result['exploit'].sum() >= 1
+
+    def test_sequential_single_edge_cases(self):
+        df, key = create_test_df()
+        params = sequential_exploration.SequentialSearchParameters(
+            budgets=[10],
+            exploration_fracs=[0.5],
+            taus=[5],
+            order_cols=['order'],
+            parameter_names=['sweep', 'replica'],
+            key=key
+        )
+        # insufficient budget
+        result = sequential_exploration.SequentialExplorationSingle(df, params, 0, 4, 0.5, 5)
+        assert result is None
+        # Data with NaNs should return None after dropna
+        df_nan = df.copy()
+        df_nan.loc[0, 'order'] = np.nan
+        result = sequential_exploration.SequentialExplorationSingle(df_nan, params, 0, 10, 0.5, 5)
+        assert result is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -10,7 +10,10 @@ if not hasattr(pd.DataFrame, 'iteritems'):
 
 # Import the module to test
 import sys
-sys.path.insert(0, '/home/runner/work/stochastic-benchmark/stochastic-benchmark/src')
+import os
+TESTS_DIR = os.path.dirname(__file__)
+SRC_PATH = os.path.abspath(os.path.join(TESTS_DIR, os.pardir, 'src'))
+sys.path.insert(0, SRC_PATH)
 
 from interpolate import (
     InterpolationParameters, 

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -6,7 +6,9 @@ from unittest.mock import patch, MagicMock
 
 # Import the module to test
 import sys
-sys.path.insert(0, '/home/runner/work/stochastic-benchmark/stochastic-benchmark/src')
+TESTS_DIR = os.path.dirname(__file__)
+SRC_PATH = os.path.abspath(os.path.join(TESTS_DIR, os.pardir, 'src'))
+sys.path.insert(0, SRC_PATH)
 
 from names import paths, param2filename, filename2param
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -7,8 +7,17 @@ import os
 if not hasattr(pd.DataFrame, 'iteritems'):
     pd.DataFrame.iteritems = pd.DataFrame.items
 
+import matplotlib.cm as mpl_cm
+import matplotlib
+if not hasattr(mpl_cm, 'register_cmap'):
+    def register_cmap(name, cmap, **kwargs):
+        matplotlib.colormaps.register(cmap, name=name)
+    mpl_cm.register_cmap = register_cmap
+
 # Add src directory to path
-sys.path.insert(0, '/home/runner/work/stochastic-benchmark/stochastic-benchmark/src')
+TESTS_DIR = os.path.dirname(__file__)
+SRC_PATH = os.path.abspath(os.path.join(TESTS_DIR, os.pardir, 'src'))
+sys.path.insert(0, SRC_PATH)
 
 
 class TestImports:

--- a/tests/test_success_metrics.py
+++ b/tests/test_success_metrics.py
@@ -5,7 +5,10 @@ from unittest.mock import patch, MagicMock
 
 # Import the module to test
 import sys
-sys.path.insert(0, '/home/runner/work/stochastic-benchmark/stochastic-benchmark/src')
+import os
+TESTS_DIR = os.path.dirname(__file__)
+SRC_PATH = os.path.abspath(os.path.join(TESTS_DIR, os.pardir, 'src'))
+sys.path.insert(0, SRC_PATH)
 
 from success_metrics import (
     SuccessMetrics,

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -6,7 +6,10 @@ from unittest.mock import patch, MagicMock
 
 # Import the module to test
 import sys
-sys.path.insert(0, '/home/runner/work/stochastic-benchmark/stochastic-benchmark/src')
+import os
+TESTS_DIR = os.path.dirname(__file__)
+SRC_PATH = os.path.abspath(os.path.join(TESTS_DIR, os.pardir, 'src'))
+sys.path.insert(0, SRC_PATH)
 
 from training import (
     best_parameters,


### PR DESCRIPTION
## Summary
- add new unit tests for random and sequential exploration
- verify single_experiment and SequentialExplorationSingle basic behavior
- ensure tests use relative paths
- patch matplotlib for compatibility and bump dill

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6887075490948327b9da95d36366becf