### PR TITLE
Fix resource_values handling

### DIFF
--- a/src/interpolate.py
+++ b/src/interpolate.py
@@ -46,7 +46,7 @@ class InterpolationParameters:
                 self.resource_value_type
             )
             warnings.warn(warn_str)
-            self.resource_value = []
+            self.resource_values = []
 
 
 def generateResourceColumn(df: pd.DataFrame, interp_params: InterpolationParameters):

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -81,6 +81,19 @@ class TestInterpolationParameters:
             assert "Unsupported resource value type" in str(w[0].message)
             assert "does not support passing in values" in str(w[1].message)
             assert params.resource_value_type == "log"
+
+    def test_invalid_resource_value_type_resets_values(self):
+        """Invalid resource types should clear resource_values."""
+        def dummy_resource_fcn(df):
+            return df['time']
+
+        params = InterpolationParameters(
+            resource_fcn=dummy_resource_fcn,
+            resource_value_type="invalid_type",
+            resource_values=[1, 2, 3]
+        )
+
+        assert params.resource_values == []
     
     def test_manual_type_without_values_warning(self):
         """Test warning for manual type without resource values."""
@@ -226,6 +239,7 @@ class TestInterpolateSingle:
         
         params = InterpolationParameters(
             resource_fcn=resource_fcn,
+            resource_value_type="manual",
             resource_values=np.array([1.5, 2.5, 3.5, 4.5])
         )
         
@@ -256,6 +270,7 @@ class TestInterpolateSingle:
         
         params = InterpolationParameters(
             resource_fcn=resource_fcn,
+            resource_value_type="manual",
             resource_values=np.array([1.5, 2.5]),
             ignore_cols=['ignore_me']
         )
@@ -282,6 +297,7 @@ class TestInterpolateSingle:
         
         params = InterpolationParameters(
             resource_fcn=resource_fcn,
+            resource_value_type="manual",
             resource_values=np.array([1.5, 2.5])
         )
         
@@ -314,6 +330,7 @@ class TestInterpolate:
         
         params = InterpolationParameters(
             resource_fcn=resource_fcn,
+            resource_value_type="manual",
             resource_values=np.array([1.5, 2.5])
         )
         
@@ -367,6 +384,7 @@ class TestInterpolateReduceMem:
         
         params = InterpolationParameters(
             resource_fcn=resource_fcn,
+            resource_value_type="manual",
             resource_values=np.array([1.5, 2.5])
         )
         


### PR DESCRIPTION
## Summary
- fix typo to ensure resource_values clears correctly
- update unit tests to specify manual resource type when giving resource values
- add test verifying invalid resource types reset resource_values

## Testing
- `python run_tests.py unit`

------
https://chatgpt.com/codex/tasks/task_b_6887a02f14308327b0216eedb981f4c9