### PR TITLE
Fix Quantile binomial search_range

### DIFF
--- a/src/stats.py
+++ b/src/stats.py
@@ -388,14 +388,13 @@ class Quantile(StatsMeasure):
 
         elif self.style == "binomial":
             search = 2
+            search_range = np.arange(-search, search + 1, 1)
             u = (
                 scipy.stats.binom.ppf(q=1 - self.alpha / 2, n=n, p=qt)
-                + np.arange(-search, search + 1, 1)
+                + search_range
                 + 1
             )
-            l = scipy.stats.binom.ppf(q=self.alpha / 2, n=n, p=qt) + np.arange(
-                -search, search + 1, 1
-            )
+            l = scipy.stats.binom.ppf(q=self.alpha / 2, n=n, p=qt) + search_range
             u[u > n] = np.inf
             l[l < 0] = -np.inf
 

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -1,0 +1,15 @@
+import pandas as pd
+import numpy as np
+
+from stats import Quantile
+
+
+def test_quantile_binomial_no_error():
+    q = Quantile(q=50, nboots=10, style="binomial")
+    base = pd.DataFrame({"x": np.arange(1, 101)})
+    lower = base - 0.1
+    upper = base + 0.1
+    cent, lb, ub = q.ConfInts(base, lower, upper)
+    assert isinstance(lb, (float, int, np.floating, np.integer))
+    assert isinstance(ub, (float, int, np.floating, np.integer))
+    assert lb < cent["x"] < ub


### PR DESCRIPTION
## Summary
- fix missing `search_range` in Quantile binomial implementation
- add regression test exercising binomial style

## Testing
- `python run_tests.py unit`

------
https://chatgpt.com/codex/tasks/task_b_6887a04226048327a4b104268cddaeb5