### PR TITLE
Fix interpolation warnings

### DIFF
--- a/src/interpolate.py
+++ b/src/interpolate.py
@@ -40,7 +40,7 @@ class InterpolationParameters:
             self.resource_value_type = "log"
 
         elif self.resource_value_type in ["data", "log"] and (
-            len(self.resource_values) >= 0
+            len(self.resource_values) > 0
         ):
             warn_str = "Resource value type {} does not support passing in values. Removing.".format(
                 self.resource_value_type
@@ -124,7 +124,7 @@ def InterpolateSingle(
     df_out = pd.DataFrame(index=interpolate_resource)
     df_out.index.name = "resource"
 
-    for colname, col in df_single.iteritems():
+    for colname, col in df_single.items():
         col = pd.to_numeric(col, errors="ignore")
         if colname in group_on:
             continue

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -77,11 +77,10 @@ class TestInterpolationParameters:
                 resource_fcn=dummy_resource_fcn,
                 resource_value_type="invalid_type"
             )
-            
-            # Expect 2 warnings: one for invalid type, one for removing values when switching to log
-            assert len(w) == 2
+
+            # Expect a single warning for invalid type
+            assert len(w) == 1
             assert "Unsupported resource value type" in str(w[0].message)
-            assert "does not support passing in values" in str(w[1].message)
             assert params.resource_value_type == "log"
 
     def test_invalid_resource_value_type_resets_values(self):


### PR DESCRIPTION
## Summary
- make `resource_values` only warn when values provided
- update iteration to use `DataFrame.items`
- adjust tests for new warning behavior

## Testing
- `python run_tests.py all`

------
https://chatgpt.com/codex/tasks/task_b_6887ad7181ac8327853e8cd7fff55a91