### PR TITLE
Allow bootstrap recovery without exp_raw

### DIFF
--- a/src/stochastic_benchmark.py
+++ b/src/stochastic_benchmark.py
@@ -1402,7 +1402,22 @@ class stochastic_benchmark:
             logger.info("Running bootstrapped results")
             group_on = self.parameter_names + self.instance_cols
             if not hasattr(self, "raw_data"):
-                self.raw_data = df_utils.read_exp_raw(self.here.raw_data)
+                if os.path.exists(self.here.raw_data) and glob.glob(
+                    os.path.join(self.here.raw_data, "*.pkl")
+                ):
+                    self.raw_data = df_utils.read_exp_raw(self.here.raw_data)
+                else:
+                    if os.path.exists(self.here.bootstrap):
+                        logger.info(
+                            "Raw data missing but bootstrap pickle found: reading results."
+                        )
+                        self.bs_results = pd.read_pickle(self.here.bootstrap)
+                        return
+                    raise Exception(
+                        "No raw data found at {} and no bootstrap pickle present".format(
+                            self.here.raw_data
+                        )
+                    )
 
             progress_dir = os.path.join(self.here.progress, "bootstrap/")
             if not os.path.exists(progress_dir):


### PR DESCRIPTION
## Summary
- relax `run_Bootstrap` so it no longer requires `exp_raw` when rerunning
- if the raw data directory is missing but a saved bootstrap pickle exists, load that instead

## Testing
- `python run_tests.py all`

------
https://chatgpt.com/codex/tasks/task_b_688829a8e5288327b15aaadc337eec13